### PR TITLE
Gov notify access key and test template details added.

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -63,6 +63,7 @@ withPipeline(type, product, component) {
     overrideVaultEnvironments(vaultOverrides)
     loadVaultSecrets(secrets)
     syncBranchesWithMaster(['demo', 'perftest', 'ithc'])
+    enableSlackNotifications('#adoption-tech')
 
     MetricsPublisher metricsPublisher = new MetricsPublisher(this, currentBuild, product, component, params.subscription )
     approvedEnvironmentRepository(params.environment, metricsPublisher) {

--- a/build.gradle
+++ b/build.gradle
@@ -339,7 +339,7 @@ bootRun {
       println("Loading secrets from vault")
 
       systemProperty 'IDAM_API_BASEURL', 'https://idam-api.aat.platform.hmcts.net'
-
+      systemProperty 'UK_GOV_NOTIFY_API_KEY', getVaultSecret('uk-gov-notify-api-key')
       systemProperty 'S2S_SECRET', getVaultSecret('s2s-secret-cos-api')
       //systemProperty 'IDAM_CASEWORKER_USERNAME', getVaultSecret('idam-caseworker-username')
       //systemProperty 'IDAM_CASEWORKER_PASSWORD', getVaultSecret('idam-caseworker-password')
@@ -373,7 +373,7 @@ functional {
       println("Loading secrets from vault")
 
       systemProperty 'IDAM_API_BASEURL', 'https://idam-api.aat.platform.hmcts.net'
-
+      systemProperty 'UK_GOV_NOTIFY_API_KEY', getVaultSecret('uk-gov-notify-api-key')
       systemProperty 'S2S_SECRET', getVaultSecret('s2s-secret-cos-api')
       //systemProperty 'IDAM_CASEWORKER_USERNAME', getVaultSecret('idam-caseworker-username')
       //systemProperty 'IDAM_CASEWORKER_PASSWORD', getVaultSecret('idam-caseworker-password')

--- a/charts/adoption-cos-api/Chart.yaml
+++ b/charts/adoption-cos-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for adoption-cos-api App
 name: adoption-cos-api
 home: https://github.com/hmcts/adoption-cos-api
-version: 0.0.2
+version: 0.0.3
 maintainers:
   - name: HMCTS Adoption team
 dependencies:

--- a/charts/adoption-cos-api/values.preview.template.yaml
+++ b/charts/adoption-cos-api/values.preview.template.yaml
@@ -10,6 +10,8 @@ java:
   keyVaults:
     adoption:
       secrets:
+        - name: uk-gov-notify-api-key
+          alias: UK_GOV_NOTIFY_API_KEY
         - name: s2s-secret-cos-api
           alias: S2S_SECRET
         - name: idam-secret

--- a/charts/adoption-cos-api/values.yaml
+++ b/charts/adoption-cos-api/values.yaml
@@ -20,6 +20,8 @@ java:
   keyVaults:
     adoption:
       secrets:
+        - name: uk-gov-notify-api-key
+          alias: UK_GOV_NOTIFY_API_KEY
         - name: s2s-secret-cos-api
           alias: S2S_SECRET
         - name: idam-secret
@@ -29,6 +31,7 @@ java:
         - name: idam-system-user-password
           alias: IDAM_SYSTEM_UPDATE_PASSWORD
   environment:
+    NOTIFY_TEMPLATE_SIGN_IN_ADOPTION_URL: https://adoption-web.{{ .Values.global.environment }}.platform.hmcts.net/
     S2S_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     IDAM_API_REDIRECT_URL: https://adoption-cos-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/authenticated
     IDAM_API_BASEURL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,6 +22,24 @@ azure:
   application-insights:
     instrumentation-key: ${APP_INSIGHTS_KEY:00000000-0000-0000-0000-000000000000}
 
+uk:
+  gov:
+    notify:
+      api:
+        key: ${UK_GOV_NOTIFY_API_KEY:dummy}
+        baseUrl: https://api.notifications.service.gov.uk
+      email:
+        templateVars:
+          signInAdoptionUrl: ${NOTIFY_TEMPLATE_SIGN_IN_ADOPTION_URL:https://adoption-web.aat.platform.hmcts.net/}
+          adoptionCourtEmail: some.email@justice.gov.uk
+        templates:
+          english:
+            TEST_EMAIL: 'b60ab1ad-fe9c-4098-81a5-ad6c976b7de3'
+            SAVE_SIGN_OUT: ''
+          welsh:
+            TEST_EMAIL: '75f5d6c5-0af6-437c-afe7-623399c11e7b'
+            SAVE_SIGN_OUT: ''
+
 s2s-authorised:
   services: ${S2S_AUTHORISED_SERVICES:ccd_data}
 


### PR DESCRIPTION

### Change description ###
Gov notify access key updated in the adoption key vault. Same has been updated in the code configs so that developers could use this while working on notification stories.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
