### PR TITLE
SNI-4802-updated last successful payment logic

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/adoption/adoptioncase/model/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/adoption/adoptioncase/model/Application.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.adoption.payment.model.PaymentStatus;
 import java.time.LocalDate;
 //import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.Collection;
 
@@ -50,9 +51,24 @@ public class Application {
 
     @JsonIgnore
     public PaymentStatus getLastPaymentStatus() {
-        return applicationPayments == null || applicationPayments.isEmpty()
+
+        if (applicationPayments != null && !applicationPayments.isEmpty()) {
+            Optional<Payment> optionalSuccessPayment = applicationPayments.stream()
+                .map(e -> e.getValue())
+                .filter(e -> e.getStatus().equals(PaymentStatus.SUCCESS))
+                .findFirst();
+            if (optionalSuccessPayment.isPresent()) {
+                return optionalSuccessPayment.get().getStatus();
+            } else {
+                return applicationPayments.get(applicationPayments.size() - 1).getValue().getStatus();
+            }
+        } else {
+            return null;
+        }
+
+        /*return applicationPayments == null || applicationPayments.isEmpty()
                 ? null
-                : applicationPayments.get(applicationPayments.size() - 1).getValue().getStatus();
+                : applicationPayments.get(applicationPayments.size() - 1).getValue().getStatus();*/
     }
 
     @JsonIgnore


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SNI-4802


### Change description ###
Citizen has issued an online adoption application, had confirmation that payment was successful but when the applicant is accessing the application now the review and payment tab is showing as 'in progress' so that application has not been submitted even though payment has been taken. The case does not appear on CCD.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
