### PR TITLE
FPET-819-testing: For Mohit this change stops the CCD definition file having all labels in AuthorisationCaseField

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/adoption/adoptioncase/caseworker/event/CaseworkerUploadDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/adoption/adoptioncase/caseworker/event/CaseworkerUploadDocument.java
@@ -46,8 +46,8 @@ public class CaseworkerUploadDocument implements CCDConfig<CaseData, State, User
                 .forAllStates()
                 .name(MANAGE_DOCUMENT)
                 .description(MANAGE_DOCUMENT)
-                .showSummary()
-                .grant(Permissions.CREATE_READ_UPDATE, UserRole.CASE_WORKER)
-                .grant(Permissions.CREATE_READ_UPDATE, UserRole.DISTRICT_JUDGE));
+                .showSummary());
+//                .grant(Permissions.CREATE_READ_UPDATE, UserRole.CASE_WORKER)
+//                .grant(Permissions.CREATE_READ_UPDATE, UserRole.DISTRICT_JUDGE));
     }
 }


### PR DESCRIPTION
A specific example is LabelApplicants-Heading