### PR TITLE
FPET-819: Imitation event needed for labels to show in EXUI

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/adoption/adoptioncase/caseworker/event/CaseworkerUploadDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/adoption/adoptioncase/caseworker/event/CaseworkerUploadDocument.java
@@ -46,8 +46,8 @@ public class CaseworkerUploadDocument implements CCDConfig<CaseData, State, User
                                    .forAllStates()
                                    .name(MANAGE_DOCUMENT)
                                    .description(MANAGE_DOCUMENT)
-                                   .showSummary()
-                                   .grant(Permissions.CREATE_READ_UPDATE, UserRole.CASE_WORKER)
-                                   .grant(Permissions.CREATE_READ_UPDATE, UserRole.DISTRICT_JUDGE));
+                                   .showSummary());
+//                                   .grant(Permissions.CREATE_READ_UPDATE, UserRole.CASE_WORKER)
+//                                   .grant(Permissions.CREATE_READ_UPDATE, UserRole.DISTRICT_JUDGE));
     }
 }


### PR DESCRIPTION
### Problem description ###

For Adoption, EXUI needs at least one event (with permissions granted) so that FieldTypes of Label are included on the AuthoristationCaseField tab of the ccd-config Excel file.

The CaseworkerUploadDocument.java file contains an event with permissions.  If we remove this file or comment out the permissions, as shown is this PR, then FieldTypes of Label do not appear on the AuthoristationCaseField next time the CCD file is generated.  Then labels don't show in EXUI.

[ccd-auth-labels-present.xlsx](https://github.com/hmcts/adoption-cos-api/files/14140079/ccd-auth-labels-present.xlsx)
[ccd-auth-labels-missing.xlsx](https://github.com/hmcts/adoption-cos-api/files/14140083/ccd-auth-labels-missing.xlsx)

Is it a requirement of EXUI to have an event to show labels?

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPET-819

https://tools.hmcts.net/jira/browse/EXUI-1308 raised, and linked to this

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
