### PR TITLE
CVE-2024-28849 updated Axios to 1.6.8 to increase follow-redirects to 1.15.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
   },
   "resolutions": {
     "minimist": "^1.2.6",
-    "axios": "^1.6.0"
+    "axios": "^1.6.8"
   },
   "dependencies": {
-    "axios": "^1.6.0"
+    "axios": "^1.6.8"
   },
   "packageManager": "yarn@3.6.4"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -331,7 +331,7 @@ __metadata:
     "@wdio/cli": ^8.10.5
     "@wdio/sauce-service": ^8.22.1
     allure-commandline: ^2.17.2
-    axios: ^1.6.0
+    axios: ^1.6.8
     axios-debug-log: ^0.8.4
     chai: ^4.3.6
     chai-as-promised: ^7.1.1
@@ -1687,14 +1687,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.6.0":
-  version: 1.6.4
-  resolution: "axios@npm:1.6.4"
+"axios@npm:^1.6.8":
+  version: 1.6.8
+  resolution: "axios@npm:1.6.8"
   dependencies:
-    follow-redirects: ^1.15.4
+    follow-redirects: ^1.15.6
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
-  checksum: 48d8af8488ac7402fae312437c0189b3b609a472fca2f7fc796129c804d98520589b6317096eba8509711d49f855a3f620b6a24ff23acd73ac26433d0383b8f9
+  checksum: bf007fa4b207d102459300698620b3b0873503c6d47bf5a8f6e43c0c64c90035a4f698b55027ca1958f61ab43723df2781c38a99711848d232cad7accbcdfcdd
   languageName: node
   linkType: hard
 
@@ -3974,13 +3974,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.4":
-  version: 1.15.4
-  resolution: "follow-redirects@npm:1.15.4"
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: e178d1deff8b23d5d24ec3f7a94cde6e47d74d0dc649c35fc9857041267c12ec5d44650a0c5597ef83056ada9ea6ca0c30e7c4f97dbf07d035086be9e6a5b7b6
+  checksum: a62c378dfc8c00f60b9c80cab158ba54e99ba0239a5dd7c81245e5a5b39d10f0c35e249c3379eae719ff0285fff88c365dd446fab19dee771f1d76252df1bbf5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Change description ###

CVE-2024-28849 updated Axios to 1.6.8 to increase follow-redirects to 1.15.6

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
