### PR TITLE
ADOP-2547 Allow Citizens to submit SoT where State is AwaitingPayment

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/adoption/adoptioncase/event/CitizenUpdateApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/adoption/adoptioncase/event/CitizenUpdateApplication.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.adoption.adoptioncase.model.CaseData;
 import uk.gov.hmcts.reform.adoption.adoptioncase.model.State;
 import uk.gov.hmcts.reform.adoption.adoptioncase.model.UserRole;
 
+import static uk.gov.hmcts.reform.adoption.adoptioncase.model.State.AwaitingPayment;
 import static uk.gov.hmcts.reform.adoption.adoptioncase.model.State.Draft;
 import static uk.gov.hmcts.reform.adoption.adoptioncase.model.State.Submitted;
 import static uk.gov.hmcts.reform.adoption.adoptioncase.model.UserRole.CITIZEN;
@@ -25,7 +26,7 @@ public class CitizenUpdateApplication implements CCDConfig<CaseData, State, User
 
         configBuilder
             .event(CITIZEN_UPDATE)
-            .forStates(Draft, Submitted)
+            .forStates(Draft, AwaitingPayment, Submitted)
             .name("Adoption case")
             .description("Adoption application update")
             .retries(120, 120)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ADOP-2547

### Change description ###
Fixes logic gap preventing Citizens from resubmitting Statement of Truth once the case State=AwaitingPayment (possible if they use the browser back button).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
