### PR TITLE
[ADOP-2408] remove redundant HPA config from charts (moved to cnp-flux)

### DIFF
--- a/charts/adoption-cos-api/Chart.yaml
+++ b/charts/adoption-cos-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for adoption-cos-api App
 name: adoption-cos-api
 home: https://github.com/hmcts/adoption-cos-api
-version: 0.0.53
+version: 0.0.54
 maintainers:
   - name: HMCTS Adoption team
 dependencies:

--- a/charts/adoption-cos-api/values.preview.template.yaml
+++ b/charts/adoption-cos-api/values.preview.template.yaml
@@ -12,10 +12,6 @@ java:
     APPLICATIONINSIGHTS_CONNECTION_STRING: ${APP_INSIGHTS_CONNECTION_KEY}
     MULTI_CHILDREN_CUI_URL: https://adoption-web-pr-956.service.core-compute-preview.internal/new-application-redirect
     LA_PORTAL_BASEURL: https://adoption-web-pr-956.service.core-compute-preview.internal/la-portal/kba-case-ref
-  devmemoryRequests: 1024Mi
-  devcpuRequests: "500m"
-  devmemoryLimits: 1527Mi
-  devcpuLimits: "2500m"
 
   keyVaults:
     adoption:

--- a/charts/adoption-cos-api/values.yaml
+++ b/charts/adoption-cos-api/values.yaml
@@ -15,11 +15,6 @@ java:
   image: hmctspublic.azurecr.io/adoption/cos-api:latest
   ingressHost: adoption-cos-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
   aadIdentityName: adoption
-  autoscaling:
-    enabled: true
-    maxReplicas: 9
-    minReplicas: 6
-    targetCPUUtilizationPercentage: 80
   keyVaults:
     adoption:
       secrets:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ADOP-2408

### Change description ###
Removed redundant HPA config from charts (moved to cnp-flux)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
