### PR TITLE
[ADOP-2551] Give Caseworkers access to ManageTTL Event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/adoption/adoptioncase/model/access/RoleToAccessProfiles.java
+++ b/src/main/java/uk/gov/hmcts/reform/adoption/adoptioncase/model/access/RoleToAccessProfiles.java
@@ -23,7 +23,7 @@ public class RoleToAccessProfiles implements CCDConfig<CaseData, State, UserRole
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.ADOPTION_GENERIC)
             .accessProfiles("caseworker-adoption").build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.CASE_WORKER)
-            .accessProfiles("caseworker-adoption-caseworker").build();
+            .accessProfiles("caseworker-adoption-caseworker", "TTL_profile").build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.COURT_ADMIN)
             .accessProfiles("caseworker-adoption-courtadmin").build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.LEGAL_ADVISOR)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ADOP-2551


### Change description ###
Give Caseworkers access to ManageTTL Event (This was removed from https://github.com/hmcts/adoption-cos-api/pull/961 so that the PR could be deployed for dry-run testing.)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
