### PR TITLE
[ADOP-2611] Sync Demo with Master restored

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -59,7 +59,7 @@ def secrets = [
 
   ]
 ]
-def branchesToSync = ['ithc', 'perftest']
+def branchesToSync = ['demo', 'ithc', 'perftest']
 def pipelineConf = new AppPipelineConfig()
 pipelineConf.vaultSecrets = secrets
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ADOP-2611

### Change description ###
I kept demo unsynced from master while I was investigating ADOP-2611, but this is no longer required.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
