### PR TITLE
forced minor upgrade of commons-beanutils

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,4 +8,11 @@
    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
    <cve>CVE-2023-35116</cve>
 </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: commons-beanutils-1.9.4.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/commons\-beanutils/commons\-beanutils@.*$</packageUrl>
+    <cve>CVE-2025-48734</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A

### Change description ###
Need to upgrade commons-beanutils to 1.11.0 (CVE-2025-48734)
Used by commons-validator which doesn't have a new version without the vulnerability.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
