### PR TITLE
ADOP-2670: Swap to Azure Artefacts from JitPack for Dep consuming

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -299,7 +299,7 @@ dependencyManagement {
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url 'https://jitpack.io' }
+  maven { url 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1' }
   // Some Cftlib services still depend on jcenter
   jcenter()
 }
@@ -354,7 +354,7 @@ dependencies {
   // required by logging-appinsights
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
 
-  // send-letter-client requires upgrade but causes gradle dependency exceptions
+  // send-letter-client requires upgrade but causes gradle dependency exceptions ADOP-2686
   implementation group: 'com.github.hmcts', name: 'send-letter-client', version: '4.0.4'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.2'
   implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.59.2'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenLocal()
     mavenCentral()
     maven {
-      url "https://jitpack.io"
+      url 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1'
       content {
         excludeGroup "com.github.ben-manes.versions"
       }
@@ -26,7 +26,7 @@ plugins {
   id 'org.springframework.boot' version '3.3.11'
   id 'com.github.ben-manes.versions' version '0.51.0'
   id 'hmcts.ccd.sdk' version '5.5.19'
-  id 'com.github.hmcts.rse-cft-lib' version '0.19.1666'
+  id 'com.github.hmcts.rse-cft-lib' version '0.19.1705'
   id 'au.com.dius.pact' version '4.3.8'
 }
 
@@ -340,7 +340,7 @@ dependencies {
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: versions.jackson
   implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.10.9'
-  implementation(group: 'com.github.hmcts', name: 'befta-fw', version: '9.1.0') {
+  implementation(group: 'com.github.hmcts', name: 'befta-fw', version: '9.2.4') {
     exclude group: 'org.apache.commons', module: 'commons-compress'
     exclude group: 'com.google.guava', module: 'guava'
     exclude group: 'org.apache.poi', module: 'poi-ooxml'
@@ -348,16 +348,16 @@ dependencies {
     exclude group: 'com.launchdarkly', module: 'launchdarkly-java-server-sdk'
   }
   implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.9.2'
-  implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.3'
-  implementation group: 'com.github.hmcts', name: 'java-logging', version: '6.1.7'
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.7'
+  implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.4'
+  implementation group: 'com.github.hmcts', name: 'java-logging', version: '6.1.9'
+  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.9'
   // required by logging-appinsights
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
 
-
+  // send-letter-client requires upgrade but causes gradle dependency exceptions
   implementation group: 'com.github.hmcts', name: 'send-letter-client', version: '4.0.4'
-  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.1.2'
-  implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.7.3'
+  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.2'
+  implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.59.2'
 
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core'
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.5.0'
@@ -380,17 +380,15 @@ dependencies {
   implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.15'
   implementation group: 'com.sendgrid', name: 'sendgrid-java', version: '4.0.1'
   implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.26.0'
-  implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '2.0.1'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: versions.s2sClient
   implementation group: 'org.apache.poi', name: 'poi', version: '5.2.5'
   implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.2.5'
   implementation group: 'org.apache.poi', name: 'poi-scratchpad', version: '5.2.4'
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.104'
-  implementation group: 'com.github.hmcts', name:'ccd-case-document-am-client', version: versions.ccdCaseDocumentAmClient
   implementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
-  testImplementation 'com.github.hmcts:fortify-client:1.4.1:all'
+  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.9'
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
     exclude group: 'junit', module: 'junit'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,4 +8,11 @@
    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
    <cve>CVE-2023-35116</cve>
 </suppress>
+<suppress>
+  <notes><![CDATA[
+ file name: commons-beanutils-1.9.4.jar
+ ]]></notes>
+  <packageUrl regex="true">^pkg:maven/commons\-beanutils/commons\-beanutils@.*$</packageUrl>
+  <cve>CVE-2025-48734</cve>
+</suppress>
 </suppressions>

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
         maven {
-            url "https://jitpack.io"
+          url 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1'
         }
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ADOP-2670

Swap from JitPack to Azure Artefacts for dependancy and plugin consuming

Contains all current published deps: https://dev.azure.com/hmcts/Artifacts/_artifacts/feed/hmcts-lib

Bumping internal dependancy version


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
