### PR TITLE
ADOP-2808 Update log4j & suppress CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -333,8 +333,8 @@ ext.libraries = [
 dependencies {
 // uncomment for local version
 // implementation group: 'com.github.hmcts', name: 'ccd-config-generator', version: 'DEV-SNAPSHOT'
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.25.3'
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.25.3'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.25.4'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.25.4'
   implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.18'
   implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.18'
   implementation group: 'com.google.guava', name: 'guava', version: '33.1.0-jre'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -124,9 +124,13 @@ Suppress CVE-2025-15104 only when Dependency-Check maps a dependency to the gene
   <suppress>
     <notes>transitive spring dependencies</notes>
     <cve>CVE-2026-22735</cve>
-  </suppress>
-  <suppress>
-    <notes>transitive spring dependencies</notes>
     <cve>CVE-2026-22737</cve>
+  </suppress>
+  <!-- ADOP-2809 -->
+  <suppress>
+    <notes>log4j-core-2.24.3.jar and log4j-api-2.25.3.jar</notes>
+    <cve>CVE-2026-34478</cve>
+    <cve>CVE-2026-34480</cve>
+    <cve>CVE-2026-34481</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -106,6 +106,20 @@ Suppress CVE-2025-15104 only when Dependency-Check maps a dependency to the gene
     <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
     <cve>CVE-2026-22732</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-security-crypto-6.4.12.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
+    <cve>CVE-2026-22748</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-security-crypto-6.4.12.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
+    <cve>CVE-2026-22746</cve>
+  </suppress>
   <!-- ADOP-2806 -->
   <suppress>
     <notes>transitive spring dependencies</notes>


### PR DESCRIPTION
### JIRA link (if applicable) ###
[ADOP-2808](https://tools.hmcts.net/jira/browse/ADOP-2808)


### Change description ###
Patch update log4j to 2.25.4
Suppress transitive CVES to be fixed under [ADOP-2809](https://tools.hmcts.net/jira/browse/ADOP-2809) (not a quick fix) and [ADOP-2799](https://tools.hmcts.net/jira/browse/ADOP-2799) (fix not yet available)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
