### PR TITLE
ADOP-2818 Update dependencies to fix pipelines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
   id 'org.sonarqube' version '5.0.0.4638'
   id 'org.springframework.boot' version '3.4.11'
   id 'com.github.ben-manes.versions' version '0.51.0'
-  id 'hmcts.ccd.sdk' version '6.7.2'
+  id 'hmcts.ccd.sdk' version '6.0.2'
   id 'com.github.hmcts.rse-cft-lib' version '0.19.1844'
   id 'au.com.dius.pact' version '4.3.8'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -352,8 +352,7 @@ dependencies {
   }
   implementation 'com.github.hmcts:core-case-data-store-client:4.9.2'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
-  implementation 'com.github.hmcts.java-logging:logging:6.1.9'
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.9'
+  implementation 'com.github.hmcts.java-logging:logging:8.0.0'
   // required by logging-appinsights
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
   id 'org.sonarqube' version '5.0.0.4638'
   id 'org.springframework.boot' version '3.4.11'
   id 'com.github.ben-manes.versions' version '0.51.0'
-  //id 'com.github.hmcts.ccd-config-generator' version '6.7.2'
+  id 'hmcts.ccd.sdk' version '6.7.2'
   id 'com.github.hmcts.rse-cft-lib' version '0.19.1844'
   id 'au.com.dius.pact' version '4.3.8'
 }
@@ -33,7 +33,6 @@ plugins {
 apply plugin: 'cz.habarta.typescript-generator'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'io.spring.dependency-management'
-apply plugin: 'com.github.hmcts:ccd-config-generator:6.7.2'
 
 group = 'uk.gov.hmcts'
 version = '0.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
   id 'org.sonarqube' version '5.0.0.4638'
   id 'org.springframework.boot' version '3.4.11'
   id 'com.github.ben-manes.versions' version '0.51.0'
-  id 'hmcts.ccd.sdk' version '5.5.19'
+  id 'com.github.hmcts.ccd-config-generator' version '6.7.2'
   id 'com.github.hmcts.rse-cft-lib' version '0.19.1844'
   id 'au.com.dius.pact' version '4.3.8'
 }
@@ -33,6 +33,7 @@ plugins {
 apply plugin: 'cz.habarta.typescript-generator'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'io.spring.dependency-management'
+//apply plugin: 'com.github.hmcts:ccd-config-generator:5.5.19'
 
 group = 'uk.gov.hmcts'
 version = '0.0.1'
@@ -382,7 +383,7 @@ dependencies {
   implementation group: 'com.sendgrid', name: 'sendgrid-java', version: '4.0.1'
   implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.28.0'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
-  implementation 'com.github.hmcts:service-auth-provider-java-client${versions.s2sClient}'
+  implementation "com.github.hmcts:service-auth-provider-java-client:${versions.s2sClient}"
   implementation group: 'org.apache.poi', name: 'poi', version: '5.4.1'
   implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.4.1'
   implementation group: 'org.apache.poi', name: 'poi-scratchpad', version: '5.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
   id 'org.sonarqube' version '5.0.0.4638'
   id 'org.springframework.boot' version '3.4.11'
   id 'com.github.ben-manes.versions' version '0.51.0'
-  id 'com.github.hmcts.ccd-config-generator' version '6.7.2'
+  //id 'com.github.hmcts.ccd-config-generator' version '6.7.2'
   id 'com.github.hmcts.rse-cft-lib' version '0.19.1844'
   id 'au.com.dius.pact' version '4.3.8'
 }
@@ -33,7 +33,7 @@ plugins {
 apply plugin: 'cz.habarta.typescript-generator'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'io.spring.dependency-management'
-//apply plugin: 'com.github.hmcts:ccd-config-generator:5.5.19'
+apply plugin: 'com.github.hmcts:ccd-config-generator:6.7.2'
 
 group = 'uk.gov.hmcts'
 version = '0.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -314,7 +314,7 @@ def versions = [
   lombok            : '1.18.38',
   reformsJavaLogging: '5.1.7',
   springBoot        : springBoot.class.package.implementationVersion,
-  s2sClient         : '4.0.2',
+  s2sClient         : '4.0.3',
   pact              : '4.1.7',
   serenity          : '4.1.6',
   ccdCaseDocumentAmClient      : '1.7.3'
@@ -350,9 +350,9 @@ dependencies {
     exclude group: 'org.apache.poi', module: 'poi'
     exclude group: 'com.launchdarkly', module: 'launchdarkly-java-server-sdk'
   }
-  implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.9.2'
+  implementation 'com.github.hmcts:core-case-data-store-client:4.9.2'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
-  implementation group: 'com.github.hmcts', name: 'java-logging', version: '6.1.9'
+  implementation 'com.github.hmcts.java-logging:logging:6.1.9'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.9'
   // required by logging-appinsights
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
@@ -382,7 +382,7 @@ dependencies {
   implementation group: 'com.sendgrid', name: 'sendgrid-java', version: '4.0.1'
   implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.28.0'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
-  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: versions.s2sClient
+  implementation 'com.github.hmcts:service-auth-provider-java-client${versions.s2sClient}'
   implementation group: 'org.apache.poi', name: 'poi', version: '5.4.1'
   implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.4.1'
   implementation group: 'org.apache.poi', name: 'poi-scratchpad', version: '5.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
   id 'org.sonarqube' version '5.0.0.4638'
   id 'org.springframework.boot' version '3.4.11'
   id 'com.github.ben-manes.versions' version '0.51.0'
-  id 'hmcts.ccd.sdk' version '6.0.2'
+  id 'hmcts.ccd.sdk' version '6.1.0'
   id 'com.github.hmcts.rse-cft-lib' version '0.19.1844'
   id 'au.com.dius.pact' version '4.3.8'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,11 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        gradlePluginPortal()
         mavenCentral()
         maven {
           url 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1'
         }
+        gradlePluginPortal()
     }
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[ADOP-2818](https://tools.hmcts.net/jira/browse/ADOP-2818)


### Change description ###
Update dependencies to fix pipeline:
- Major: java-logging to v8
- Major: ccd.sdk (aka ccd-config-generator) to 6.1
- Patch: service-auth-provider-java-client to 4.0.3

Move gradlePluginPortal below Mvn call as advised in https://hmcts-reform.slack.com/archives/CA4F2MAFR/p1778163137701889

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
