### PR TITLE
ADOP-2759 remove pipelineJavaVersion workaround in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,6 @@ plugins {
   id 'au.com.dius.pact' version '4.3.8'
 }
 
-// This is cheating workaround to how Platops Jenkins pipeline detecting Java version
-// For more details on how the pipeline detect and setup Java version,
-// Ref: cnp-jenkins-library src/uk/gov/hmcts/contino/GradleBuilder.groovy function setupToolVersion()
-// We will need to move our nested Gradle build script to this root script in the near future
-// var pipelineJavaVersion = "JavaLanguageVersion.of(21)"
-
 apply plugin: 'cz.habarta.typescript-generator'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'io.spring.dependency-management'

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ plugins {
 // For more details on how the pipeline detect and setup Java version,
 // Ref: cnp-jenkins-library src/uk/gov/hmcts/contino/GradleBuilder.groovy function setupToolVersion()
 // We will need to move our nested Gradle build script to this root script in the near future
-var pipelineJavaVersion = "JavaLanguageVersion.of(21)"
+// var pipelineJavaVersion = "JavaLanguageVersion.of(21)"
 
 apply plugin: 'cz.habarta.typescript-generator'
 apply plugin: 'com.github.ben-manes.versions'


### PR DESCRIPTION
### JIRA link (if applicable) ###
[ADOP-2759](https://tools.hmcts.net/jira/browse/ADOP-2759)

### Change description ###
Remove pipelineJavaVersion in build.gradle as workaround no longer needed to prevent pipeline nagger Java 21 alerts.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

- [ ] [SonarCloud](https://sonarcloud.io/project/pull_requests_list?id=uk.gov.hmcts.reform%3Aadoption-cos-api) has been reviewed