### PR TITLE
Update axios + suppress spring transitive dependency CVEs

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -379,6 +379,12 @@ Suppress CVE-2025-15104 only when Dependency-Check maps a dependency to the gene
     <cve>CVE-2026-22740</cve>
     <cve>CVE-2026-22745</cve>
     <cve>CVE-2026-22741</cve>
+    <cve>CVE-2026-41842</cve>
+    <cve>CVE-2026-41850</cve>
+    <cve>CVE-2026-41851</cve>
+    <cve>CVE-2026-41840</cve>
+    <cve>CVE-2026-41841</cve>
+    <cve>CVE-2026-41843</cve>
   </suppress>
   <!-- ADOP-2809 -->
   <suppress>
@@ -402,6 +408,12 @@ Suppress CVE-2025-15104 only when Dependency-Check maps a dependency to the gene
     <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot\-starter\-aop@.*$</packageUrl>
     <cve>CVE-2023-20873</cve>
     <cve>CVE-2023-20883</cve>
+    <cve>CVE-2026-41842</cve>
+    <cve>CVE-2026-41850</cve>
+    <cve>CVE-2026-41851</cve>
+    <cve>CVE-2026-41840</cve>
+    <cve>CVE-2026-41841</cve>
+    <cve>CVE-2026-41843</cve>
   </suppress>
 
   <!-- To be fixed in ADOP-2777: Tomcat 10.1.54 CVE suppressions - pending upgrade to patched version -->

--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
   },
   "resolutions": {
     "minimist": "^1.2.8",
-    "axios": "^1.15.2",
+    "axios": "^1.17.0",
     "follow-redirects": "^1.16.0"
   },
   "dependencies": {
-    "axios": "^1.15.2"
+    "axios": "^1.17.0"
   },
   "packageManager": "yarn@3.8.7"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -331,7 +331,7 @@ __metadata:
     "@wdio/cli": ^8.10.5
     "@wdio/sauce-service": ^8.22.1
     allure-commandline: ^2.17.2
-    axios: ^1.15.2
+    axios: ^1.17.0
     axios-debug-log: ^0.8.4
     chai: ^4.3.6
     chai-as-promised: ^7.1.1
@@ -1668,14 +1668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.15.2":
-  version: 1.15.2
-  resolution: "axios@npm:1.15.2"
+"axios@npm:^1.17.0":
+  version: 1.17.0
+  resolution: "axios@npm:1.17.0"
   dependencies:
-    follow-redirects: ^1.15.11
+    follow-redirects: ^1.16.0
     form-data: ^4.0.5
+    https-proxy-agent: ^5.0.1
     proxy-from-env: ^2.1.0
-  checksum: e7d208b751959c7c6936417b870d6286979e0dff17784ae230d3988e754b6322682cb136e25669b534072b6f44c08715801ab961227eb8cc075323d9fda8ad43
+  checksum: 4bf030d85fde8720ebd112115223f162844505e4e44687749ba36e7b37241ef2e875fb8a5406be82097f4bc907362dc74f3ae94ea2c9cffca4fd2b2c37cafc5c
   languageName: node
   linkType: hard
 
@@ -4937,7 +4938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:5.0.1":
+"https-proxy-agent@npm:5.0.1, https-proxy-agent@npm:^5.0.1":
   version: 5.0.1
   resolution: "https-proxy-agent@npm:5.0.1"
   dependencies:


### PR DESCRIPTION
### JIRA link (if applicable) ###
[ADOP-2806](https://tools.hmcts.net/jira/browse/ADOP-2806)
[ADOP-2832](https://tools.hmcts.net/jira/browse/ADOP-2832)

### Change description ###

- Minor update: axios to 1.17.0 to fix new CVE (axios is only used by E2E tests)
- Suppress spring transitive dependency CVEs for fixing in ADOP-2806 & Hystrix retirement (ADOP-2832)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
