### PR TITLE
ADOP-2874 move CCD config/definition generation after ACR login

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -156,20 +156,22 @@ withPipeline(type, product, component) {
     ]
 
     dir("${WORKSPACE}") {
-      steps.archiveArtifacts  allowEmptyArchive: true, artifacts: "build/reports/tests/functional/**/*"
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: "build/reports/tests/functional/**/*"
     }
 
-    env.ENVIRONMENT="prod"
-    env.CASE_API_URL="http://adoption-cos-api-prod.service.core-compute-prod.internal"
-    env.CCD_DEF_NAME="prod"
-    env.DEFINITION_STORE_URL_BASE="http://ccd-definition-store-api-prod.service.core-compute-prod.internal"
-    env.CITIZEN_UPDATE_CASE_STATE_ENABLED=true
+    env.ENVIRONMENT = "prod"
+    env.CASE_API_URL = "http://adoption-cos-api-prod.service.core-compute-prod.internal"
+    env.CCD_DEF_NAME = "prod"
+    env.DEFINITION_STORE_URL_BASE = "http://ccd-definition-store-api-prod.service.core-compute-prod.internal"
+    env.CITIZEN_UPDATE_CASE_STATE_ENABLED = true
     env.SERVICE_AUTH_MICROSERVICE = "adoption_cos_api"
     env.SERVICE_AUTH_PROVIDER_URL = "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"
     env.IDAM_API_URL_BASE = "https://idam-api.platform.hmcts.net"
     env.S2S_URL_BASE = "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"
     env.BEFTA_S2S_CLIENT_ID = "ccd_data"
+  }
 
+  before('highleveldatasetup') {
     builder.gradle('generateCCDConfig --rerun-tasks')
     generateDefinitions()
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[ADOP-2874](https://tools.hmcts.net/jira/browse/ADOP-2874)

### Change description ###
Fix intermittent authentication issue by moving CCD config/definition generation until later in the pipeline, i.e. after the pipeline has completed the ACR login.

Replicates PlatOps fix for nfdiv and sptribs (https://github.com/hmcts/nfdiv-case-api/pull/5108)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
