### PR TITLE
ADOP-2874 move CCD config/definition generation after ACR login

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -169,9 +169,7 @@ withPipeline(type, product, component) {
     env.IDAM_API_URL_BASE = "https://idam-api.platform.hmcts.net"
     env.S2S_URL_BASE = "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"
     env.BEFTA_S2S_CLIENT_ID = "ccd_data"
-  }
 
-  before('highleveldatasetup') {
     builder.gradle('generateCCDConfig --rerun-tasks')
     generateDefinitions()
   }
@@ -198,7 +196,7 @@ withPipeline(type, product, component) {
     ]
   }
 
-  afterAlways('checkout') {
+  before('highleveldatasetup') {
     builder.gradle('generateCCDConfig')
     generateDefinitions()
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[ADOP-2874](https://tools.hmcts.net/jira/browse/ADOP-2874)

### Change description ###
Fix intermittent authentication issue by moving CCD config/definition generation until later in the pipeline, i.e. after the pipeline has completed the ACR login.

Replicates PlatOps fix for nfdiv and sptribs (https://github.com/hmcts/nfdiv-case-api/pull/5108)

NB Changed the wrong steps in https://github.com/hmcts/adoption-cos-api/pull/1096


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
