### PR TITLE
ADOP-2881 New suppressions & Reorganisation of suppressions

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,14 +2,6 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes><![CDATA[
-   file name: jackson-databind-2.15.3.jar
-     description: jackson-databind through 2.15.2 allows attackers to cause a denial of service or other unspecified impact via a crafted object that uses cyclic dependencies. NOTE: the vendor's perspective is that this is not a valid vulnerability report, because the steps of constructing a cyclic data structure and trying to serialize it cannot be achieved by an external attacker.
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-    <cve>CVE-2023-35116</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
    file name: commons-beanutils-1.9.4.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/commons\-beanutils/commons\-beanutils@.*$</packageUrl>
@@ -22,76 +14,7 @@
     <packageUrl regex="true">^pkg:maven/commons-configuration/commons-configuration@.*$</packageUrl>
     <cve>CVE-2025-46392</cve>
   </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-core-10.1.44.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-    <cve>CVE-2025-55754</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-core-10.1.44.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-    <cve>CVE-2025-55752</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-core-10.1.44.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-    <cve>CVE-2025-61795</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: log4j-core-2.24.3.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-core@.*$</packageUrl>
-    <cve>CVE-2025-68161</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-core-10.1.47.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-    <cve>CVE-2025-66614</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-core-10.1.47.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-    <cve>CVE-2026-24733</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-core-10.1.47.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-    <cve>CVE-2026-24734</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-websocket-10.1.47.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
-    <cve>CVE-2025-66614</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-websocket-10.1.47.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
-    <cve>CVE-2026-24733</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-websocket-10.1.47.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
-    <cve>CVE-2026-24734</cve>
-  </suppress>
+
   <suppress>
     <notes><![CDATA[
    file name: kotlin-stdlib-1.9.25.jar
@@ -113,238 +36,24 @@
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib\-jdk8@.*$</packageUrl>
     <cve>CVE-2020-29582</cve>
   </suppress>
-  <!-- Log4j CVE-2026 suppressions - pending upgrade: ADOP-TODO -->
+
+  <!-- ADOP-2809 -->
   <suppress>
     <notes><![CDATA[
-   file name: log4j-api-2.25.3.jar / log4j-core-2.24.3.jar
-   Suppressed pending upgrade to patched Log4j version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-api@.*$</packageUrl>
+   file name: log4j-core-2.24.3.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-core@.*$</packageUrl>
+    <cve>CVE-2025-68161</cve>
+  </suppress>
+  <suppress>
+    <notes>log4j-core-2.24.3.jar and log4j-api-2.25.3.jar</notes>
     <cve>CVE-2026-34478</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: log4j-api-2.25.3.jar / log4j-core-2.24.3.jar
-   Suppressed pending upgrade to patched Log4j version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-api@.*$</packageUrl>
     <cve>CVE-2026-34480</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: log4j-api-2.25.3.jar / log4j-core-2.24.3.jar
-   Suppressed pending upgrade to patched Log4j version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-api@.*$</packageUrl>
     <cve>CVE-2026-34481</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: log4j-core-2.24.3.jar
-   Suppressed pending upgrade to patched Log4j version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-core@.*$</packageUrl>
-    <cve>CVE-2026-34478</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: log4j-core-2.24.3.jar
-   Suppressed pending upgrade to patched Log4j version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-core@.*$</packageUrl>
-    <cve>CVE-2026-34480</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: log4j-core-2.24.3.jar
-   Suppressed pending upgrade to patched Log4j version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-core@.*$</packageUrl>
-    <cve>CVE-2026-34481</cve>
+    <cve>CVE-2026-34479</cve>
+    <cve>CVE-2026-34477</cve>
   </suppress>
 
-  <!-- Spring Framework CVE-2026 suppressions - pending upgrade: ADOP-TODO -->
-  <suppress>
-    <notes><![CDATA[
-   Affects spring-framework 6.2.12 (aop, beans, context, core, expression, jcl, webmvc).
-   Suppressed pending upgrade to patched Spring Framework version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-.*@.*$</packageUrl>
-    <cve>CVE-2026-22737</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects spring-framework 6.2.12 (aop, beans, context, core, expression, jcl, webmvc).
-   Suppressed pending upgrade to patched Spring Framework version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-.*@.*$</packageUrl>
-    <cve>CVE-2026-22735</cve>
-  </suppress>
-
-  <!-- Spring Boot CVE-2026 suppressions - pending upgrade: ADOP-TODO -->
-  <suppress>
-    <notes><![CDATA[
-   Affects spring-boot 3.4.11 and all starters.
-   Suppressed pending upgrade to patched Spring Boot version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot.*@.*$</packageUrl>
-    <cve>CVE-2026-22731</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects spring-boot 3.4.11 and all starters.
-   Suppressed pending upgrade to patched Spring Boot version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot.*@.*$</packageUrl>
-    <cve>CVE-2026-22733</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects spring-boot 3.4.11 and all starters.
-   Suppressed pending upgrade to patched Spring Boot version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot.*@.*$</packageUrl>
-    <cve>CVE-2026-40972</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects spring-boot 3.4.11 and all starters.
-   Suppressed pending upgrade to patched Spring Boot version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot.*@.*$</packageUrl>
-    <cve>CVE-2026-40973</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects spring-boot 3.4.11 and all starters.
-   Suppressed pending upgrade to patched Spring Boot version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot.*@.*$</packageUrl>
-    <cve>CVE-2026-40975</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects spring-boot 3.4.11 and all starters.
-   Suppressed pending upgrade to patched Spring Boot version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot.*@.*$</packageUrl>
-    <cve>CVE-2026-40977</cve>
-  </suppress>
-
-  <!-- Spring Security CVE-2026 suppressions - pending upgrade: ADOP-TODO -->
-  <suppress>
-    <notes><![CDATA[
-   Affects spring-security-crypto 6.4.12.
-   Suppressed pending upgrade to patched Spring Security version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-.*@.*$</packageUrl>
-    <cve>CVE-2026-22732</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects spring-security-crypto 6.4.12.
-   Suppressed pending upgrade to patched Spring Security version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-.*@.*$</packageUrl>
-    <cve>CVE-2026-22748</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects spring-security-crypto 6.4.12.
-   Suppressed pending upgrade to patched Spring Security version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-.*@.*$</packageUrl>
-    <cve>CVE-2026-22746</cve>
-  </suppress>
-
-  <!-- Tomcat CVE-2026 suppressions - pending upgrade: ADOP-TODO -->
-  <suppress>
-    <notes><![CDATA[
-   Affects tomcat-embed-core / tomcat-embed-websocket 10.1.52.
-   Suppressed pending upgrade to patched Tomcat version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*@.*$</packageUrl>
-    <cve>CVE-2026-29145</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects tomcat-embed-core / tomcat-embed-websocket 10.1.52.
-   Suppressed pending upgrade to patched Tomcat version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*@.*$</packageUrl>
-    <cve>CVE-2026-24880</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects tomcat-embed-core / tomcat-embed-websocket 10.1.52.
-   Suppressed pending upgrade to patched Tomcat version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*@.*$</packageUrl>
-    <cve>CVE-2026-29129</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects tomcat-embed-core / tomcat-embed-websocket 10.1.52.
-   Suppressed pending upgrade to patched Tomcat version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*@.*$</packageUrl>
-    <cve>CVE-2026-29146</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects tomcat-embed-core / tomcat-embed-websocket 10.1.52.
-   Suppressed pending upgrade to patched Tomcat version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*@.*$</packageUrl>
-    <cve>CVE-2026-34483</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects tomcat-embed-core / tomcat-embed-websocket 10.1.52.
-   Suppressed pending upgrade to patched Tomcat version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*@.*$</packageUrl>
-    <cve>CVE-2026-34487</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects tomcat-embed-core / tomcat-embed-websocket 10.1.52.
-   Suppressed pending upgrade to patched Tomcat version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*@.*$</packageUrl>
-    <cve>CVE-2026-34500</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects tomcat-embed-core / tomcat-embed-websocket 10.1.52.
-   Suppressed pending upgrade to patched Tomcat version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*@.*$</packageUrl>
-    <cve>CVE-2026-25854</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   Affects tomcat-embed-core / tomcat-embed-websocket 10.1.52.
-   Suppressed pending upgrade to patched Tomcat version. Raise Jira to track upgrade.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*@.*$</packageUrl>
-    <cve>CVE-2026-32990</cve>
-  </suppress>
-
-  <suppress until="2027-04-02Z">
-    <notes><![CDATA[
-Suppress CVE-2025-15104 only when Dependency-Check maps a dependency to the generic CPE
-"validator:validator" (known false-positive for various *-validator libraries).
-    ]]></notes>
-
-    <!-- Matches: cpe:2.3:a:validator:validator:<any>:*:*:*:*:*:*:* -->
-    <cpe>cpe:2.3:a:validator:validator:*:*:*:*:*:*:*:*</cpe>
-
-    <!-- Optional: also cover any legacy CPE format -->
-    <cpe>cpe:/a:validator:validator</cpe>
-
-    <cve>CVE-2025-15104</cve>
-  </suppress>
   <!-- ADOP-2800 -->
   <suppress>
     <notes><![CDATA[
@@ -376,7 +85,8 @@ Suppress CVE-2025-15104 only when Dependency-Check maps a dependency to the gene
   </suppress>
   <!-- ADOP-2806 -->
   <suppress>
-    <notes>transitive spring dependencies</notes>
+    <notes>transitive spring framework dependencies
+      (aop, beans, context, core, expression, jcl, webmvc)</notes>
     <cve>CVE-2026-22735</cve>
     <cve>CVE-2026-22737</cve>
     <cve>CVE-2026-22740</cve>
@@ -397,15 +107,7 @@ Suppress CVE-2025-15104 only when Dependency-Check maps a dependency to the gene
     <cve>CVE-2026-41854</cve>
     <cve>CVE-2026-41853</cve>
   </suppress>
-  <!-- ADOP-2809 -->
-  <suppress>
-    <notes>log4j-core-2.24.3.jar and log4j-api-2.25.3.jar</notes>
-    <cve>CVE-2026-34478</cve>
-    <cve>CVE-2026-34480</cve>
-    <cve>CVE-2026-34481</cve>
-    <cve>CVE-2026-34479</cve>
-    <cve>CVE-2026-34477</cve>
-  </suppress>
+
   <!-- To be fixed in ADOP-2832 : spring-boot-starter-aop 2.3.12.RELEASE CVE suppressions -->
   <!-- Hystrix 2.2.10.RELEASE transitively pulls spring-boot-starter-aop:2.3.12.RELEASE.        -->
   <!-- The application itself runs Spring Boot 4 and is not affected by these 2.x vulnerabilities. -->
@@ -438,10 +140,37 @@ Suppress CVE-2025-15104 only when Dependency-Check maps a dependency to the gene
   <!-- To be fixed in ADOP-2777: Tomcat 10.1.54 CVE suppressions - pending upgrade to patched version -->
   <suppress>
     <notes><![CDATA[
+   file name: tomcat-embed-core-10.1.44.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
+    <cve>CVE-2025-55754</cve>
+    <cve>CVE-2025-55752</cve>
+    <cve>CVE-2025-61795</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: tomcat-embed-core/websocket 10.1.47.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*@.*$</packageUrl>
+    <cve>CVE-2025-66614</cve>
+    <cve>CVE-2026-24733</cve>
+    <cve>CVE-2026-24734</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
    Affects tomcat-embed-core / tomcat-embed-websocket 10.1.54 (pinned for hystrix compatibility).
    Suppressed pending Tomcat upgrade. Raise Jira to track upgrade.
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*@.*$</packageUrl>
+    <cve>CVE-2026-29145</cve>
+    <cve>CVE-2026-24880</cve>
+    <cve>CVE-2026-29129</cve>
+    <cve>CVE-2026-29146</cve>
+    <cve>CVE-2026-34483</cve>
+    <cve>CVE-2026-34487</cve>
+    <cve>CVE-2026-34500</cve>
+    <cve>CVE-2026-25854</cve>
+    <cve>CVE-2026-32990</cve>
     <cve>CVE-2026-41293</cve>
     <cve>CVE-2026-41284</cve>
     <cve>CVE-2026-42498</cve>
@@ -454,4 +183,21 @@ Suppress CVE-2025-15104 only when Dependency-Check maps a dependency to the gene
     <notes><![CDATA[file name: spring-boot-3.4.11.jar]]></notes>
     <cve>CVE-2026-40974</cve>
   </suppress>
+
+  <!-- Suspected false positive -->
+  <suppress until="2027-04-02Z">
+    <notes><![CDATA[
+Suppress CVE-2025-15104 only when Dependency-Check maps a dependency to the generic CPE
+"validator:validator" (known false-positive for various *-validator libraries).
+    ]]></notes>
+
+    <!-- Matches: cpe:2.3:a:validator:validator:<any>:*:*:*:*:*:*:* -->
+    <cpe>cpe:2.3:a:validator:validator:*:*:*:*:*:*:*:*</cpe>
+
+    <!-- Optional: also cover any legacy CPE format -->
+    <cpe>cpe:/a:validator:validator</cpe>
+
+    <cve>CVE-2025-15104</cve>
+  </suppress>
+
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,12 +15,26 @@
     <cve>CVE-2025-46392</cve>
   </suppress>
 
+  <!-- Fix in ADOP-2882 jackson-databind -->
+  <suppress>
+    <notes>jackson-databind-2.15.3.jar, jackson-databind-2.19.2.jar,
+      cucumber-core-7.18.0.jar (shaded: com.fasterxml.jackson.core:jackson-databind:2.17.1)</notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+    <cve>CVE-2023-35116</cve>
+    <cve>CVE-2026-54512</cve>
+    <cve>CVE-2026-54513</cve>
+    <cve>CVE-2026-54514</cve>
+    <cve>CVE-2026-54515</cve>
+  </suppress>
+
+  <!-- Fix in ADOP-2762 kotlin -->
   <suppress>
     <notes><![CDATA[
    file name: kotlin-stdlib-1.9.25.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib@.*$</packageUrl>
     <cve>CVE-2020-29582</cve>
+    <cve>CVE-2026-53914</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -28,6 +42,7 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib\-jdk7@.*$</packageUrl>
     <cve>CVE-2020-29582</cve>
+    <cve>CVE-2026-53914</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -35,9 +50,10 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib\-jdk8@.*$</packageUrl>
     <cve>CVE-2020-29582</cve>
+    <cve>CVE-2026-53914</cve>
   </suppress>
 
-  <!-- ADOP-2809 -->
+  <!-- Fix in ADOP-2809 log4j -->
   <suppress>
     <notes><![CDATA[
    file name: log4j-core-2.24.3.jar
@@ -54,7 +70,7 @@
     <cve>CVE-2026-34477</cve>
   </suppress>
 
-  <!-- ADOP-2800 -->
+  <!-- Fix in ADOP-2800 spring boot -->
   <suppress>
     <notes><![CDATA[
    file name: spring-boot-3.4.13.jar
@@ -71,7 +87,7 @@
     <cve>CVE-2026-40975</cve>
     <cve>CVE-2026-40977</cve>
   </suppress>
-  <!-- ADOP-2799 -->
+  <!-- Fix in ADOP-2799 spring-security-crypto -->
   <suppress>
     <notes>spring-security-crypto</notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
@@ -82,8 +98,11 @@
     <cve>CVE-2026-40988</cve>
     <cve>CVE-2026-41003</cve>
     <cve>CVE-2026-41694</cve>
+    <cve>CVE-2026-47838</cve>
+    <cve>CVE-2026-41706</cve>
   </suppress>
-  <!-- ADOP-2806 -->
+
+  <!-- Fix in ADOP-2806 spring framework -->
   <suppress>
     <notes>transitive spring framework dependencies
       (aop, beans, context, core, expression, jcl, webmvc)</notes>
@@ -106,9 +125,10 @@
     <cve>CVE-2026-41852</cve>
     <cve>CVE-2026-41854</cve>
     <cve>CVE-2026-41853</cve>
+    <cve>CVE-2026-41855</cve>
   </suppress>
 
-  <!-- To be fixed in ADOP-2832 : spring-boot-starter-aop 2.3.12.RELEASE CVE suppressions -->
+  <!-- Fix in ADOP-2832 : spring-boot-starter-aop 2.3.12.RELEASE CVE suppressions -->
   <!-- Hystrix 2.2.10.RELEASE transitively pulls spring-boot-starter-aop:2.3.12.RELEASE.        -->
   <!-- The application itself runs Spring Boot 4 and is not affected by these 2.x vulnerabilities. -->
   <!-- Remove once spring-cloud-starter-netflix-hystrix is replaced or upgraded.                   -->
@@ -137,7 +157,7 @@
     <cve>CVE-2026-41853</cve>
   </suppress>
 
-  <!-- To be fixed in ADOP-2777: Tomcat 10.1.54 CVE suppressions - pending upgrade to patched version -->
+  <!-- Fix in ADOP-2777: Tomcat -->
   <suppress>
     <notes><![CDATA[
    file name: tomcat-embed-core-10.1.44.jar


### PR DESCRIPTION
### JIRA link (if applicable) ###
[ADOP-2881](https://tools.hmcts.net/jira/browse/ADOP-2881)

### Change description ###

- jackson-databind suppressions to be fixed in [ADOP-2882](https://tools.hmcts.net/jira/browse/ADOP-2882)
- kotlin suppressions to be fixed in [ADOP-2762](https://tools.hmcts.net/jira/browse/ADOP-2762)
- spring boot suppressions to be fixed in [ADOP-2800](https://tools.hmcts.net/jira/browse/ADOP-2800)
- spring framework suppressions to be fixed in [ADOP-2806](https://tools.hmcts.net/jira/browse/ADOP-2806)
- ordered alphabetically
- removed duplicate suppression
- collapsed suppressions sharing same version into one block



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
