### PR TITLE
ADOP-2912 move axios to devDependencies and update to v1.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@wdio/cli": "^8.10.5",
     "@wdio/sauce-service": "^8.22.1",
     "allure-commandline": "^2.17.2",
+    "axios": "^1.18.0",
     "axios-debug-log": "^0.8.4",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
@@ -49,12 +50,9 @@
   },
   "resolutions": {
     "minimist": "^1.2.8",
-    "axios": "^1.17.0",
+    "axios": "^1.18.0",
     "follow-redirects": "^1.16.0",
     "form-data": "^4.0.6"
-  },
-  "dependencies": {
-    "axios": "^1.17.0"
   },
   "packageManager": "yarn@4.14.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,7 +561,7 @@ __metadata:
     "@wdio/cli": "npm:^8.10.5"
     "@wdio/sauce-service": "npm:^8.22.1"
     allure-commandline: "npm:^2.17.2"
-    axios: "npm:^1.17.0"
+    axios: "npm:^1.18.0"
     axios-debug-log: "npm:^0.8.4"
     chai: "npm:^4.3.6"
     chai-as-promised: "npm:^7.1.1"
@@ -2316,15 +2316,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.17.0":
-  version: 1.17.0
-  resolution: "axios@npm:1.17.0"
+"axios@npm:^1.18.0":
+  version: 1.18.1
+  resolution: "axios@npm:1.18.1"
   dependencies:
     follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/bc6995122fb9ca1431836579ae53fdd94894ad3d676de229d474da6465bc323ad93e8bf0b3bdb33ec4fbd460d93485ef2b5240e97d778700c029bf053c7f75cd
+  checksum: 10/c4cdced3ee0a9bf7dcae189fbc74a124aa079d4f04dbd995e602d39c1419476e8d021f87ee39ac8d8398e5a55e6d0b986238b3645f0d9177ac80de87c2a73f18
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[ADOP-2912](https://tools.hmcts.net/jira/browse/ADOP-2912)

### Change description ###
Move axios to devDependencies (only used by e2e tests) and update to v1.18 to fix CVE.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
